### PR TITLE
fix: conditional retry

### DIFF
--- a/.github/workflows/export.yaml
+++ b/.github/workflows/export.yaml
@@ -118,9 +118,8 @@ jobs:
 
       - run: |
           uv run --frozen --extra export immich-model upload "$MODEL_NAME" \
-            --hf-model-name "$HF_MODEL_NAME" --hf-organization "$ORGANIZATION" --hf-branch v2
+            --hf-organization "$ORGANIZATION" --hf-branch v2
         env:
           MODEL_NAME: ${{ inputs.model-name }}
-          HF_MODEL_NAME: ${{ inputs.hf-name || inputs.model-name }}
           ORGANIZATION: ${{ inputs.organization }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/immich_model/cli.py
+++ b/immich_model/cli.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from typer import Argument, Exit, Option, Typer, echo
 
 from ._cli import ModelName
-from .constants import DELETE_PATTERNS, FIXTURES
+from .constants import DELETE_PATTERNS, FIXTURES, RETRY_STATUS
 from .onnx.cli import app as onnx_app
 from .rknn.cli import app as rknn_app
 
@@ -82,14 +82,23 @@ def upload(
 ) -> None:
     """Upload an exported model directory (<input-dir>/<model-name>) to a Hugging Face repo."""
     from huggingface_hub import create_branch, create_repo, upload_folder
-    from tenacity import retry, stop_after_attempt, wait_fixed
+    from huggingface_hub.errors import HfHubHTTPError
+    from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
     if not hf_model_name:
         hf_model_name = model_name
     model_dir = input_dir / model_name
     repo_id = f"{hf_organization}/{hf_model_name}"
 
-    @retry(stop=stop_after_attempt(5), wait=wait_fixed(5))
+    def transient(error: BaseException) -> bool:
+        return isinstance(error, HfHubHTTPError) and error.response.status_code in RETRY_STATUS
+
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=wait_exponential(multiplier=2, max=60),
+        retry=retry_if_exception(transient),
+        reraise=True,
+    )
     def upload_model() -> None:
         create_repo(repo_id, exist_ok=True)
         if hf_branch != "main":

--- a/immich_model/constants.py
+++ b/immich_model/constants.py
@@ -213,6 +213,7 @@ def variant_dir(sets: Sequence[DimSet], dims: Mapping[str, int]) -> str:
 # glob to delete old UUID blobs when reuploading models
 _uuid_char = "[a-fA-F0-9]"
 _uuid_glob = _uuid_char * 8 + "-" + _uuid_char * 4 + "-" + _uuid_char * 4 + "-" + _uuid_char * 4 + "-" + _uuid_char * 12
+RETRY_STATUS = frozenset({429, 500, 502, 503, 504})
 DELETE_PATTERNS = [
     "**/*onnx*",
     "**/*rknpu*",


### PR DESCRIPTION
### Description

It was retrying validation errors and attempts to upload to a read-only mirror. Now it only retries for transient errors and with exponential instead of fixed backoff.

Also fixes the upload trying to create invalid repos like `immich-testing/M-CLIP/XLM-Roberta-Large-Vit-B-16Plus`.